### PR TITLE
chore: add timeout to actions and codespaces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ concurrency:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     # runs-on: self-hosted
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Detailed Description
- Make the actions not run longer than 15
- make the codespaces shutdown after 10 min